### PR TITLE
Linux specific fix and let divide by conquer respect current mouse position more

### DIFF
--- a/supermouser.py
+++ b/supermouser.py
@@ -1,16 +1,43 @@
+#!/usr/bin/env python3
 # pip install pyuserinput pyqt5
 # on linux also: sudo apt-get install  python-xlib
+import os
+import psutil
 import sys
 from pymouse import PyMouse
+from sys import platform
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 
+
+def kill_proc_tree(pid, including_parent=True):
+    """
+    Perhaps only needed in Linux, no matter what the proces just wouldn't exit.
+    Even after manually controlling the event loop, for now this is a workaround.
+    """
+    parent = psutil.Process(pid)
+    for child in parent.children(recursive=True):
+        child.kill()
+    if including_parent:
+        parent.kill()
+
+
 class CustomWindow(QMainWindow):
     def __init__(self, pymouse): 
-        super().__init__(); 
-        self.__resetWorkingArea()
+        super().__init__()
         self.mouse = pymouse
+        self.currentScreenSize = app.desktop().availableGeometry()
+        # number of pixels "excluded" using divide & conquer
+        self.leftExcluded = 0
+        self.rightExcluded = 0
+        self.topExcluded = 0
+        self.bottomExcluded = 0
+        # corresponding rectangles to visualize excluded areas
+        self.leftRect = QRect(0, 0, 0, 0)
+        self.rightRect = QRect(0, 0, 0, 0)
+        self.topRect = QRect(0, 0, 0, 0)
+        self.bottomRect = QRect(0, 0, 0, 0)
 
     def paintEvent(self, event=None):
         painter = QPainter(self)
@@ -19,114 +46,66 @@ class CustomWindow(QMainWindow):
         painter.setBrush(Qt.white)
         painter.setPen(QPen(Qt.white))   
 
-        drawWorkingArea = False
-        if drawWorkingArea:
-            painter.fillRect(
-                self.workingArea[0],
-                self.workingArea[1], 
-                self.workingArea[2],
-                self.workingArea[3], 
-		Qt.white
-	    )
-        else:
-            painter.fillRect(
-                0,
-                0, 
-                self.currentScreenSize.width(),
-                self.workingArea[1],
-		Qt.white
-	    )
-            painter.fillRect(
-                0,
-                self.workingArea[1], 
-                self.workingArea[0],
-                self.currentScreenSize.height(),
-		Qt.white
-	    )
-            painter.fillRect(
-                self.workingArea[0] + self.workingArea[2],
-                self.workingArea[1], 
-                self.currentScreenSize.width(),
-                self.workingArea[3], 
-		Qt.white
-	    )
-            painter.fillRect(
-                self.workingArea[0],
-                self.workingArea[1] + self.workingArea[3], 
-                self.currentScreenSize.width(),
-                self.currentScreenSize.height(),
-		Qt.white
-	    )
-
-    def __resetWorkingArea(self):
-        self.currentScreenSize = QDesktopWidget().screenGeometry(-1)
-        self.workingArea = [0, 0, self.currentScreenSize.width(), self.currentScreenSize.height()]
-
-    def __updateWorkingArea(self, newWorkingArea):
-        self.workingArea = newWorkingArea
-        self.mouse.move(
-            self.workingArea[0] + (self.workingArea[2] / 2),
-            self.workingArea[1] + (self.workingArea[3] / 2),
-        )
-        self.repaint()
+        painter.fillRect(self.leftRect, Qt.white)
+        painter.fillRect(self.rightRect, Qt.white)
+        painter.fillRect(self.topRect, Qt.white)
+        painter.fillRect(self.bottomRect, Qt.white)
 
     def keyPressEvent(self, e):
+        x, y = self.mouse.position()
+        width = self.currentScreenSize.width()
+        height = self.currentScreenSize.height()
+
         if e.key() == Qt.Key_H:
-            self.__updateWorkingArea([
-		self.workingArea[0], 
-                self.workingArea[1],
-                self.workingArea[2] / 2, 
-                self.workingArea[3]
-            ])
-            return
-
-        if e.key() == Qt.Key_J:
-            self.__updateWorkingArea([
-		self.workingArea[0], 
-                self.workingArea[1] + (self.workingArea[3] / 2),
-                self.workingArea[2], 
-                self.workingArea[3] / 2
-            ])
-            return
-
-        if e.key() == Qt.Key_K:
-            self.__updateWorkingArea([
-		self.workingArea[0], 
-                self.workingArea[1], 
-                self.workingArea[2], 
-                self.workingArea[3] / 2
-            ])
+            self.rightExcluded = width - x
+            self.rightRect = QRect(x, 0, width, height)
+            self.repaint()
+            self.mouse.move(int(x - ((x - self.leftExcluded) / 2)), y)
             return
 
         if e.key() == Qt.Key_L:
-            self.__updateWorkingArea([
-		self.workingArea[0] + (self.workingArea[2] / 2),
-                self.workingArea[1], 
-                self.workingArea[2] / 2, 
-                self.workingArea[3]
-            ])
+            self.leftExcluded = x
+            self.leftRect = QRect(0, 0, x, height)
+            self.repaint()
+            self.mouse.move(int(x + ((width - x - self.rightExcluded) / 2)), y)
+            return
+
+        if e.key() == Qt.Key_J:
+            self.topExcluded = y
+            self.topRect = QRect(0, 0, width, y)
+            self.repaint()
+            self.mouse.move(x, int(y + ((height - y - self.bottomExcluded) / 2)))
+            return
+
+        if e.key() == Qt.Key_K:
+            self.bottomExcluded = height - y
+            self.bottomRect = QRect(0, y, width, height)
+            self.repaint()
+            self.mouse.move(x, int(y - ((y - self.topExcluded) / 2)))
             return
 
         if e.key() == Qt.Key_F:
-            self.mouse.click(
-                self.mouse.position()[0],
-                self.mouse.position()[1],
-                1 # left click
-            )
-            self.__resetWorkingArea()
+            self.close()
+            self.mouse.click(x, y, 1)  # left click
+            kill_proc_tree(os.getpid())
+            return
+
+        if e.key() == Qt.Key_D:
+            self.close()
+            self.mouse.click(x, y, 1)  # left click
+            self.mouse.click(x, y, 1)  # left click
+            kill_proc_tree(os.getpid())
             return
 
         if e.key() == Qt.Key_G:
-            self.mouse.click(
-                self.mouse.position()[0],
-                self.mouse.position()[1],
-                2 # right click
-            )
-            self.__resetWorkingArea()
+            self.close()
+            self.mouse.click(x, y, 2)  # right click
+            kill_proc_tree(os.getpid())
             return
 
         if e.key() == Qt.Key_Q:
             self.close()
+            kill_proc_tree(os.getpid())
 
 
 app = QApplication(sys.argv)
@@ -136,13 +115,29 @@ mouse = PyMouse()
 window = CustomWindow(mouse)
 
 window.setWindowFlags(
-    Qt.FramelessWindowHint 
-    | Qt.WindowStaysOnTopHint 
+    Qt.FramelessWindowHint
+    | Qt.WindowStaysOnTopHint
+    #| Qt.WindowSystemMenuHint
+    #| Qt.WindowTitleHint
     #| Qt.NoDropShadowWindowHint
+    #| Qt.Tool
 )
+
 window.setAttribute(Qt.WA_NoSystemBackground, True)
 window.setAttribute(Qt.WA_TranslucentBackground, True)
 
+if platform == "linux" or platform == "linux2":
+    window.setAttribute(Qt.WA_X11NetWmWindowTypeSplash, True)
+elif platform == "darwin":
+    pass
+elif platform == "win32":
+    pass
+
 # Run the application
-window.showMaximized()
+# window.showFullScreen()  # on my X11 window manager this prevents all other windows from being drawn
+# window.showMaximized()   # .. and this also didn't do anything..
+dimensions = app.desktop().availableGeometry()
+window.move(0, 0)
+window.resize(dimensions.width(), dimensions.height())
+window.showNormal()
 sys.exit(app.exec_())

--- a/supermouser.py
+++ b/supermouser.py
@@ -4,6 +4,7 @@
 import os
 import psutil
 import sys
+import time
 from pymouse import PyMouse
 from sys import platform
 from PyQt5.QtCore import *
@@ -32,11 +33,15 @@ def current_screen_size(mouse_position):
            return screen_geom
     return app.desktop().availableGeometry(-1)
 
+
 class CustomWindow(QMainWindow):
     def __init__(self, pymouse): 
         super().__init__()
         self.mouse = pymouse
         self.currentScreenSize = current_screen_size(self.mouse.position())
+        self.reset()
+
+    def reset(self):
         # number of pixels "excluded" using divide & conquer
         self.leftExcluded = 0
         self.rightExcluded = 0
@@ -108,21 +113,30 @@ class CustomWindow(QMainWindow):
 
         if e.key() == Qt.Key_F:
             self.close()
+            time.sleep(0.1)
             mouse_click(x, y, 1)  # left click
             kill_proc_tree(os.getpid())
             return
 
         if e.key() == Qt.Key_D:
             self.close()
+            time.sleep(0.1)
             mouse_click(x, y, 1)  # left click
+            time.sleep(0.1)
             mouse_click(x, y, 1)  # left click
             kill_proc_tree(os.getpid())
             return
 
         if e.key() == Qt.Key_G:
             self.close()
+            time.sleep(0.1)
             mouse_click(x, y, 2)  # right click
             kill_proc_tree(os.getpid())
+            return
+
+        if e.key() == Qt.Key_M:
+            self.reset()
+            self.repaint()
             return
 
         if e.key() == Qt.Key_Q or e.key() == Qt.Key_Escape:
@@ -139,27 +153,47 @@ window = CustomWindow(mouse)
 window.setWindowFlags(
     Qt.FramelessWindowHint
     | Qt.WindowStaysOnTopHint
-    #| Qt.WindowSystemMenuHint
-    #| Qt.WindowTitleHint
-    #| Qt.NoDropShadowWindowHint
-    #| Qt.Tool
+    | Qt.X11BypassWindowManagerHint
+   |  Qt.ActiveWindowFocusReason
+    | Qt.Tool
+    | Qt.ToolTip
+    | Qt.WindowActive
+ #   | Qt.WindowSystemMenuHint
+ #   | Qt.WindowTitleHint
+ #   | Qt.Widget
+ #   | Qt.NoDropShadowWindowHint
+#    | Qt.Popup
+#    | Qt.SplashScreen
+#    | Qt.Drawer
+#    | Qt.Sheet
+#    | Qt.Dialog
 )
-
+#window.setParent(0);# // Create TopLevel-Widget
+#setAttribute(Qt::WA_NoSystemBackground, true);
+#setAttribute(Qt::WA_TranslucentBackground, true);  
+#setAttribute(Qt::WA_PaintOnScreen); // not needed in Qt 5.2 and up
 window.setAttribute(Qt.WA_NoSystemBackground, True)
 window.setAttribute(Qt.WA_TranslucentBackground, True)
+if False:
+    window.setAttribute(Qt.WA_PaintOnScreen, True)
+    window.setStyleSheet("background:transparent;")
 
 if platform == "linux" or platform == "linux2":
-    window.setAttribute(Qt.WA_X11NetWmWindowTypeSplash, True)
+    pass # window.setAttribute(Qt.WA_X11NetWmWindowTypeSplash, True)
 elif platform == "darwin":
     pass
 elif platform == "win32":
     pass
 
 # Run the application
-# window.showFullScreen()  # on my X11 window manager this prevents all other windows from being drawn
-# window.showMaximized()   # .. and this also didn't do anything..
+#window.showFullScreen()  # on my X11 window manager this prevents all other windows from being drawn
+#window.showMaximized()   # .. and this also didn't do anything..
 dimensions = current_screen_size(mouse.position())
-window.move(0, 0)
+print(dimensions)
+window.move(dimensions.left(), dimensions.top())
 window.resize(dimensions.width(), dimensions.height())
 window.showNormal()
+window.raise_()
+window.activateWindow()
+
 sys.exit(app.exec_())


### PR DESCRIPTION
I realize it was just a draft POC but when I got supermouser working on Linux I discovered that the divide mechanism wasn't respecting the current x & y of the cursor 100% 

For example moving to the right it would divide and put the mouse centered in the right block, but that's confusing if the mouse was initially somewhere in the top of the screen..

So I tried fixing it in the workingArea approach, but I was making it unreadable in the process with stuff like "if first move then use current mouse X here". Maybe there is a way to do it more concise, and simply keep one working area rectangle, but for now I just changed it into keeping track of the "excluded area" together with rectangles. Movement is only allowed half the distance of the remaining area.. and original X is kept when only Y is updated, and vice versa..